### PR TITLE
Add basic setup.py extraction

### DIFF
--- a/metadata_please/source_checkout.py
+++ b/metadata_please/source_checkout.py
@@ -245,12 +245,15 @@ def from_setup_py_checkout(path: Path) -> bytes:
         return b""
 
     buf = []
-    if r := v.setup_call_args.get("install_requires"):
+
+    r = v.setup_call_args.get("install_requires")
+    if r:
         if r is UNKNOWN:
             raise ValueError("Complex setup call can't extract reqs")
         for dep in r:
             buf.append(f"Requires-Dist: {dep}\n")
-    if er := v.setup_call_args.get("extras_require"):
+    er = v.setup_call_args.get("extras_require")
+    if er:
         if er is UNKNOWN:
             raise ValueError("Complex setup call can't extract extras")
         for k, deps in er.items():

--- a/metadata_please/source_checkout_ast.py
+++ b/metadata_please/source_checkout_ast.py
@@ -1,0 +1,121 @@
+"""
+Reads static values from setup.py when they are simple enough.
+
+With the goal of just getting dependencies, and returning a clear error if we don't understand, this has a simpler
+
+This only reads ~50% of current setup.py, vs dowsing which is more like 80%.
+
+I experimented with a more complex version of this in
+[dowsing](https://github.com/python-packaging/dowsing/) with a goal of 100%
+coverage of open source
+"""
+
+import ast
+
+
+# Copied from orig-index
+class ShortCircuitingVisitor(ast.NodeVisitor):
+    """
+    This visitor behaves more like libcst.CSTVisitor in that a visit_ method
+    can return true or false to specify whether children get visited, and the
+    visiting of children is not the responsibility of the visit_ method.
+    """
+
+    def visit(self, node):
+        method = "visit_" + node.__class__.__name__
+        visitor = getattr(self, method, self.generic_visit)
+        rv = visitor(node)
+        if rv:
+            self.visit_children(node)
+
+    def visit_children(self, node):
+        for field, value in ast.iter_fields(node):
+            if isinstance(value, list):
+                for item in value:
+                    if isinstance(item, ast.AST):
+                        self.visit(item)
+            elif isinstance(value, ast.AST):
+                self.visit(value)
+
+    def generic_visit(self, node) -> bool:
+        return True
+
+
+class QualifiedNameSaver(ShortCircuitingVisitor):
+    """Similar to LibCST's QualifiedNameProvider except simpler and wronger"""
+
+    def __init__(self):
+        super().__init__()
+        self.qualified_name_prefixes = {}
+
+    def qualified_name(self, node: ast.AST) -> str:
+        if isinstance(node, ast.Attribute):
+            return self.qualified_name(node.value) + "." + node.attr
+        elif isinstance(node, ast.Expr):
+            return self.qualified_name(node.value)
+        elif isinstance(node, ast.Name):
+            if new := self.qualified_name_prefixes.get(node.id):
+                return new
+            return f"<locals>.{node.id}"
+        else:
+            raise ValueError(f"Complex expression: {type(node)}")
+
+    def visit_Import(self, node: ast.Import):
+        # .names
+        #     alias = (identifier name, identifier? asname)
+        for a in node.names:
+            self.qualified_name_prefixes[a.asname or a.name] = a.name
+
+    def visit_ImportFrom(self, node: ast.ImportFrom):
+        # .identifier / .level
+        # .names
+        #     alias = (identifier name, identifier? asname)
+        if node.module:
+            prefix = f"{node.module}."
+        else:
+            prefix = "." * node.level
+
+        for a in node.names:
+            self.qualified_name_prefixes[a.asname or a.name] = prefix + a.name
+
+
+class Unknown:
+    pass
+
+
+UNKNOWN = Unknown()
+
+
+class SetupFindingVisitor(QualifiedNameSaver):
+    def __init__(self):
+        super().__init__()
+        self.setup_call_args = None
+        self.setup_call_kwargs = None
+
+    def visit_Call(self, node):
+        # .func (expr, can just be name)
+        # .args
+        # .keywords
+        qn = self.qualified_name(node.func)
+        if qn in ("setuptools.setup", "distutils.setup"):
+            self.setup_call_args = d = {}
+            self.setup_call_kwargs = False
+            # Positional args are rarely used
+            for k in node.keywords:
+                if not k.arg:
+                    self.setup_call_kwargs = True
+                else:
+                    try:
+                        d[k.arg] = ast.literal_eval(k.value)
+                    except ValueError:  # malformed node or string...
+                        d[k.arg] = UNKNOWN
+
+
+if __name__ == "__main__":
+    import sys
+    from pathlib import Path
+
+    mod = ast.parse(Path(sys.argv[1]).read_bytes())
+    v = SetupFindingVisitor()
+    v.visit(mod)
+    print(v.setup_call_args)


### PR DESCRIPTION
Not that impressive, but a starting point that works for simple enough cases with only stdlib.

1. It's less accurate about qualified names of imports
2. It can't handle assignment to locals and using that as an arg
3. It marks too-complex cases a bit more obviously, although kwargs currently get a pass
4. It requires that `setup.py` (if it exists) be parseable in the current python, and raises otherwise
5. Could probably use some more tests to validate I got the dotted lookup even remotely right (`import setuptools` and `from setuptools import setup` are all I've really checked)

I would estimate this only works for ~40% of the real-world `setup.py`, while the [dowsing impl](https://github.com/python-packaging/dowsing/blob/main/dowsing/setuptools/setup_py_parsing.py) works for more like ~70%.  I'm intending to use this for `hdeps .` support right now, but the same basic code would be useful in a future advice that migrates to pep621 metadata (right now we don't save any positions, so editing the args is not possible).  See [past use in opine](https://github.com/python-packaging/opine/blob/2b710a2477abe90ac543f657f00d3083977ed6fe/opine/suggestions/move_setup_py_to_declarative.py#L84-L87) for how this might be used.